### PR TITLE
Include lwip header before using if_nametoindex

### DIFF
--- a/asio/include/asio/detail/impl/socket_ops.ipp
+++ b/asio/include/asio/detail/impl/socket_ops.ipp
@@ -41,6 +41,10 @@
 #endif // defined(ASIO_WINDOWS) || defined(__CYGWIN__)
        // || defined(__MACH__) && defined(__APPLE__)
 
+#ifdef ESP_PLATFORM
+#include <lwip/if_api.h>
+#endif
+
 #include "asio/detail/push_options.hpp"
 
 namespace asio {


### PR DESCRIPTION
Not including the header yields linker errors. The header contains
preprocessors defines setting if_nametoindex and if_indextonam to
lwip_ip_xxx.

Note: this PR depends on https://github.com/espressif/esp-idf/pull/4186